### PR TITLE
Fix unused declared type variables in method definitions

### DIFF
--- a/src/radware_sigcompress.jl
+++ b/src/radware_sigcompress.jl
@@ -264,7 +264,7 @@ function read_from_properties(read_property::Function, src::Any, ::Type{RadwareS
     RadwareSigcompress(shft)
 end
 
-function write_to_properties!(write_property::Function, dest::Any, codec::RadwareSigcompress) where T
+function write_to_properties!(write_property::Function, dest::Any, codec::RadwareSigcompress)
     write_property(dest, :radware_sigcompress_shift, codec.shift)
     nothing
 end


### PR DESCRIPTION
When precompiling, the package throws a warning that one type variables in the method definition for `write_to_properties!` is declared but not used. I have removed it to avoid the warning.