### PR TITLE
fix for conversion of string to unit

### DIFF
--- a/src/abstract_io.jl
+++ b/src/abstract_io.jl
@@ -108,7 +108,7 @@ function units_from_string(s::AbstractString)
         NoUnits
     else
         try
-            Unitful.lookup_units(Unitful, Meta.parse(s))
+            uparse(s)
         catch e
             if e isa ErrorException
                 rethrow(ArgumentError("Unknown physical unit \"$s\""))


### PR DESCRIPTION
resolves the issue that `units_from_string(s)` does not return a unit but a Julia expression in case of `s = "ns ^ -1"`