### PR TITLE
Add support for parsing the elementary charge `e` from UnitfulAtomic.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [compat]
 ArgCheck = "1, 2"

--- a/src/LegendDataTypes.jl
+++ b/src/LegendDataTypes.jl
@@ -10,6 +10,7 @@ using StaticArrays
 using StatsBase
 using StructArrays
 using Unitful
+using UnitfulAtomic
 
 import Tables
 import TypedTables

--- a/src/abstract_io.jl
+++ b/src/abstract_io.jl
@@ -110,6 +110,7 @@ function units_from_string(s::AbstractString)
         try
             uparse(s)
         catch e
+            s == "e" && return u"e_au" # parse "e" as u"e_au" from UnitfulAtomic
             if e isa ErrorException
                 rethrow(ArgumentError("Unknown physical unit \"$s\""))
             else


### PR DESCRIPTION
When saving elements with the unit `u"e_au"` (elementary charge from [UnitfulAtomic.jl](https://github.com/sostock/UnitfulAtomic.jl), the unit is saved as `"e"`. LegendDataTypes.jl is not able to parse this. In this PR, a quick fix for parsing `"e"` correctly is added.

We might wanna think about making sure that LegendDataTypes.jl always saves the unit in a parsable string that can be always understood by `uparse`, e.g. using [UnitfulParsableString.jl](https://github.com/michikawa07/UnitfulParsableString.jl) instead of `"$u"` to convert a unit into a string in [`units_to_string`](https://github.com/legend-exp/LegendDataTypes.jl/blob/06a1dc91589e1fe6379290595904f486d35f70b6/src/abstract_io.jl#L122).