### PR TITLE
Fix unit processing for `percent` and `permille`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - name: Cache artifacts
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -80,7 +80,7 @@ jobs:
         with:
           version: '1'
       - name: Cache artifacts
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/src/abstract_io.jl
+++ b/src/abstract_io.jl
@@ -114,6 +114,8 @@ function units_from_string(s::AbstractString)
             uparse(s, unit_context=[Unitful, UnitfulAtomic])
         catch e
             s == "e" && return u"e_au" # parse "e" as u"e_au" from UnitfulAtomic
+            s == "o/oo" && return u"permille" # parse "o/oo" as u"permille" from Unitful
+            s = "o/o" && return u"percent" # parse "o/o" as u"percent" from Unitful
             if e isa ErrorException
                 rethrow(ArgumentError("Unknown physical unit \"$s\""))
             else


### PR DESCRIPTION
Parse `o/o` and `o/oo` as `percent` and `permille` units while loading. These units are used in the context of the FlashCam decoding in the `extra` section (s. [here](https://github.com/legend-exp/legend-daq2lh5/blob/main/src/daq2lh5/fc/fc_status_decoder.py)) 

Why need ASAP a description of units in the `dataformat-specs`. This is way too much work to debug every time.......

c.f. @gipert @ggmarshall 

@DaGeibl : I still need to update the `tests/` on `LegendHDF5IO.jl` and the bump the compat for this too work properly.
